### PR TITLE
docs: add Examples/Documentation index

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,0 +1,34 @@
+# Documentation Index
+
+- [](&)Documentation/Accessibility/README.md
+- [](&)Documentation/AccessibilityAPI.md
+- [](&)Documentation/AccessibilityGuide.md
+- [](&)Documentation/API-Reference.md
+- [](&)Documentation/API.md
+- [](&)Documentation/Best-Practices.md
+- [](&)Documentation/ButtonAPI.md
+- [](&)Documentation/CardAPI.md
+- [](&)Documentation/ColorGuide.md
+- [](&)Documentation/Components/Navigation.md
+- [](&)Documentation/Components/README.md
+- [](&)Documentation/ComponentsAPI.md
+- [](&)Documentation/ComponentsGuide.md
+- [](&)Documentation/CustomizationGuide.md
+- [](&)Documentation/DesignTokensAPI.md
+- [](&)Documentation/DesignTokensGuide.md
+- [](&)Documentation/FormAPI.md
+- [](&)Documentation/Getting-Started.md
+- [](&)Documentation/GettingStarted.md
+- [](&)Documentation/GettingStarted/README.md
+- [](&)Documentation/Installation.md
+- [](&)Documentation/NavigationAPI.md
+- [](&)Documentation/Performance/README.md
+- [](&)Documentation/PerformanceGuide.md
+- [](&)Documentation/ResponsiveAPI.md
+- [](&)Documentation/ResponsiveDesignGuide.md
+- [](&)Documentation/SecurityGuide.md
+- [](&)Documentation/Testing/README.md
+- [](&)Documentation/TestingGuide.md
+- [](&)Documentation/Themes/README.md
+- [](&)Documentation/Troubleshooting.md
+- [](&)Documentation/TypographyGuide.md

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -1,24 +1,18 @@
-# 💡 Examples
+# Examples Index
 
-Welcome to our comprehensive examples collection! Here you'll find practical implementations and usage patterns for our framework.
-
-## 📱 Available Examples
-
-### Basic Example
-- **File**: `BasicExample.swift`
-- **Description**: Simple implementation showing fundamental usage
-- **Difficulty**: Beginner
-- **Use Case**: Quick prototyping and learning
-
-## 🚀 Getting Started
-
-1. **Choose an example** that matches your skill level
-2. **Copy the code** into your project
-3. **Customize** according to your needs
-4. **Build and run** to see it in action
-
-## 📚 Related Documentation
-
-- [Getting Started](Documentation/GettingStarted.md)
-- [API Reference](Documentation/API.md)
-- [Installation Guide](Documentation/Installation.md)
+- ``Examples/AccessibilityExamples/AccessibilityExamples.swift
+- ``Examples/AdvancedExample.swift
+- ``Examples/AdvancedExamples/AdvancedExamples.swift
+- ``Examples/BasicExample.swift
+- ``Examples/BasicExamples/AlertExamples.swift
+- ``Examples/BasicExamples/BadgeExamples.swift
+- ``Examples/BasicExamples/ButtonExamples.swift
+- ``Examples/BasicExamples/CardExamples.swift
+- ``Examples/BasicExamples/ModalExamples.swift
+- ``Examples/BasicExamples/NavigationExample.swift
+- ``Examples/BasicExamples/ProgressIndicatorExamples.swift
+- ``Examples/BasicExamples/SearchFieldExamples.swift
+- ``Examples/BasicExamples/TextFieldExamples.swift
+- ``Examples/CustomizationExamples/CustomizationExamples.swift
+- ``Examples/LayoutExamples/LayoutExamples.swift
+- ``Examples/ResponsiveExamples/ResponsiveExamples.swift


### PR DESCRIPTION
Adds repo-specific indices for Examples and Documentation folders. English-only; no placeholders.